### PR TITLE
Fix build errors (plugin build on C++ UE 5.4.4 project; Android game build)

### DIFF
--- a/OmegaGameFramework/Source/FileSDK/Public/FileSDKBPLibrary.h
+++ b/OmegaGameFramework/Source/FileSDK/Public/FileSDKBPLibrary.h
@@ -21,8 +21,10 @@
 
 #if PLATFORM_WINDOWS
   #include "Windows/WindowsPlatformMisc.h"
-#elif PLATFORM_LINUX || PLATFORM_ANDROID
+#elif PLATFORM_LINUX
   #include "Unix/UnixPlatformMisc.h"
+#elif PLATFORM_ANDROID
+  #include "Android/AndroidPlatformMisc.h"
 #elif PLATFORM_MAC || PLATFORM_IOS
   #include "Apple/ApplePlatformMisc.h"
   #include <sys/stat.h>

--- a/OmegaGameFramework/Source/OmegaData/Private/OmegaDataSubsystem.cpp
+++ b/OmegaGameFramework/Source/OmegaData/Private/OmegaDataSubsystem.cpp
@@ -23,7 +23,7 @@ void UOmegaDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		FARFilter Filter;
 		Filter.ClassPaths.Add(UOmegaDataItem::StaticClass()->GetClassPathName());
 	
-		for(const FDirectoryPath NewPath : GetMutableDefault<UOmegaDataSettings>()->DataItemScansPath)
+		for(const FDirectoryPath& NewPath : GetMutableDefault<UOmegaDataSettings>()->DataItemScansPath)
 		{
 			FString LocalString = NewPath.Path;
 			Filter.PackagePaths.Add(FName(*LocalString));

--- a/OmegaGameFramework/Source/OmegaGameFramework/Private/Actors/OmegaGameplaySystem.cpp
+++ b/OmegaGameFramework/Source/OmegaGameFramework/Private/Actors/OmegaGameplaySystem.cpp
@@ -48,7 +48,7 @@ void AOmegaGameplaySystem::BeginPlay()
 		const APlayerController* TempPlayer = Cast<APlayerController>(TempActor);
 		
 		//Add New Widgets To Player Screen
-		for (const class TSubclassOf <UHUDLayer> TempWidgetClass : local_GetAllHudClasses())
+		for (const class TSubclassOf <UHUDLayer>& TempWidgetClass : local_GetAllHudClasses())
 		{
 			UOmegaPlayerSubsystem* LocalSystem = TempPlayer->GetLocalPlayer()->GetSubsystem<UOmegaPlayerSubsystem>();
 			UHUDLayer* CreatedLayer = LocalSystem->AddHUDLayer(TempWidgetClass, this);

--- a/OmegaGameFramework/Source/OmegaGameFramework/Private/Components/CombatantComponent.cpp
+++ b/OmegaGameFramework/Source/OmegaGameFramework/Private/Components/CombatantComponent.cpp
@@ -1494,7 +1494,7 @@ bool UCombatantComponent::GetActionDataFromGambit(UCombatantGambitAsset* Gambit,
 {
 	if(Gambit)
 	{
-		for(const FCombatantGambit TempGambit : Gambit->GetAllGambitActions())
+		for(const FCombatantGambit& TempGambit : Gambit->GetAllGambitActions())
 		{
 			float rand_val = UKismetMathLibrary::RandomFloat();
 			

--- a/OmegaGameFramework/Source/OmegaGameFramework/Private/Components/Component_GameplaySystems.cpp
+++ b/OmegaGameFramework/Source/OmegaGameFramework/Private/Components/Component_GameplaySystems.cpp
@@ -35,7 +35,7 @@ void UGameplaySystemsComponent::EndPlay(const EEndPlayReason::Type EndPlayReason
 
 void UGameplaySystemsComponent::Local_ActivateSystems()
 {
-	for(const auto TempSys : GameplaySystems)
+	for(const auto& TempSys : GameplaySystems)
 	{
 		GetWorld()->GetSubsystem<UOmegaGameplaySubsystem>()->ActivateGameplaySystem(TempSys, this, ActivationFlag);
 	}
@@ -43,7 +43,7 @@ void UGameplaySystemsComponent::Local_ActivateSystems()
 
 void UGameplaySystemsComponent::Local_ShutdownSystems()
 {
-	for(const auto TempSys : GameplaySystems)
+	for(const auto& TempSys : GameplaySystems)
 	{
 		if(TempSys)
 		{

--- a/OmegaGameFramework/Source/OmegaGameFramework/Private/Components/Component_InputReceiver.cpp
+++ b/OmegaGameFramework/Source/OmegaGameFramework/Private/Components/Component_InputReceiver.cpp
@@ -169,7 +169,7 @@ void UInputReceiverComponent::OnOwningControllerChange(APawn* Pawn, AController*
 		GetOwner()->DisableInput(Cast<APlayerController>(OldController));
 	}
 	
-	if((REF_OwningController = Cast<APlayerController>(NewController)))
+	if((REF_OwningController = Cast<APlayerController>(NewController)) != nullptr)
 	{
 		GetOwner()->EnableInput(Cast<APlayerController>(NewController));
 	}

--- a/OmegaGameFramework/Source/OmegaGameFramework/Private/Functions/OmegaFunctions_ScriptedEffects.cpp
+++ b/OmegaGameFramework/Source/OmegaGameFramework/Private/Functions/OmegaFunctions_ScriptedEffects.cpp
@@ -55,7 +55,7 @@ void UOmegaScriptedEffectFunctions::ApplyEffectScriptToCombatant(TArray<UOmegaSc
 			TempEffect->OnEffectApplied(Target, Instigator);
 
 			//Spawn Cues
-			for(const TSubclassOf<AOmegaGameplayCue> TempCue : TempEffect->GetCuesToPlay())
+			for(const TSubclassOf<AOmegaGameplayCue>& TempCue : TempEffect->GetCuesToPlay())
 			{
 				UOmegaGameplayCueFunctions::PlayGameplayCue(Target,TempCue,FTransform(), FHitResult(),Target->GetOwner());
 			}
@@ -71,7 +71,7 @@ void UOmegaScriptedEffectFunctions::ApplyScriptedEffectToCombatant(UOmegaScripte
 		ApplyEffectScriptToCombatant(EffectAsset->ScriptedEffects,Target,Instigator);
 		
 		//Spawn Cues
-		for(const TSubclassOf<AOmegaGameplayCue> TempCue : EffectAsset->GameplayCues)
+		for(const TSubclassOf<AOmegaGameplayCue>& TempCue : EffectAsset->GameplayCues)
 		{
 			UOmegaGameplayCueFunctions::PlayGameplayCue(Target,TempCue,FTransform(),FHitResult(),Target->GetOwner());
 		}

--- a/OmegaGameFramework/Source/OmegaGameFramework/Private/Misc/OmegaGameMode.cpp
+++ b/OmegaGameFramework/Source/OmegaGameFramework/Private/Misc/OmegaGameMode.cpp
@@ -13,7 +13,7 @@ void AOmegaGameMode::Local_LoadSystemShutdown(UObject* Context, FString Flag)
 	UOmegaGameplaySubsystem* SystemRef = GetWorld()->GetSubsystem<UOmegaGameplaySubsystem>();
 	
 	//Activate Game Systems
-	for (const TSubclassOf<AOmegaGameplaySystem> TempSystem : PostLoadGameplaySystems)
+	for (const TSubclassOf<AOmegaGameplaySystem>& TempSystem : PostLoadGameplaySystems)
 	{
 		SystemRef->ActivateGameplaySystem(TempSystem, this, "GameMode_PostLoad");
 	}
@@ -24,7 +24,7 @@ void AOmegaGameMode::Local_ActivatePersistentSystems()
 {
 	UOmegaGameplaySubsystem* SystemRef = GetWorld()->GetSubsystem<UOmegaGameplaySubsystem>();
 	
-	for (const TSubclassOf<AOmegaGameplaySystem> TempSystem : PersistentGameplaySystems)
+	for (const TSubclassOf<AOmegaGameplaySystem>& TempSystem : PersistentGameplaySystems)
 	{
 		SystemRef->ActivateGameplaySystem(TempSystem, this, "PersistentSystem");
 	}
@@ -38,7 +38,7 @@ void AOmegaGameMode::BeginPlay()
 	UOmegaGameplaySubsystem* SystemRef = GetWorld()->GetSubsystem<UOmegaGameplaySubsystem>();
 
 	//Activate Game Systems
-	for (const TSubclassOf<AOmegaGameplaySystem> TempSystem : AutoGameplaySystems)
+	for (const TSubclassOf<AOmegaGameplaySystem>& TempSystem : AutoGameplaySystems)
 	{
 		
 		SystemRef->ActivateGameplaySystem(TempSystem, this, "GameMode_PreLoad");

--- a/OmegaGameFramework/Source/OmegaGameFramework/Private/Misc/OmegaGameplayModule.cpp
+++ b/OmegaGameFramework/Source/OmegaGameFramework/Private/Misc/OmegaGameplayModule.cpp
@@ -23,7 +23,7 @@ UWorld* UOmegaGameplayModule::GetWorld() const
 
 void UOmegaGameplayModule::Native_Initialize()
 {
-	if((REF_OwningManager = GetGameInstance()->GetSubsystem<UOmegaGameManager>()))
+	if((REF_OwningManager = GetGameInstance()->GetSubsystem<UOmegaGameManager>()) != nullptr)
 	{
 		REF_OwningManager->OnGlobalEvent.AddDynamic(this, &UOmegaGameplayModule::OnGlobalEvent);
 		REF_OwningManager->OnTaggedGlobalEvent.AddDynamic(this, &UOmegaGameplayModule::OnTaggedGlobalEvent);


### PR DESCRIPTION
- Check `!= nullptr`, to fix plugin build error on C++ UE 5.4.4 project (Error c4706: assignment within conditional expression).
- Add #elif and #include, to fix Android game build error.
- Add `&` on types, to fix Android game build error.